### PR TITLE
Inherit static members as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ function HelloWorld() {
 }
 
 HelloWorld.prototype = Object.create(Hello.prototype);
+HelloWorld.prototype.constructor = HelloWorld;
 
 HelloWorld.prototype.echo = function echo() {
   alert(Hello.prototype.hello.call(this));


### PR DESCRIPTION
`Object.create()` only makes a copy of the superclass' prototype, which only includes the instance properties. To inherit the superclass's static properties attached to the parent's constructor, you need to assign the constructor property in the newly copied prototype to the subclass' constructor.
