### PR TITLE
Inherit static method from super class

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ function HelloWorld() {
 }
 
 HelloWorld.prototype = Object.create(Hello.prototype);
+HelloWorld.sayHelloAll = Hello.sayHelloAll;
 
 HelloWorld.prototype.echo = function echo() {
   alert(Hello.prototype.hello.call(this));


### PR DESCRIPTION
Using Object.create doesn't copy the static method references to subclasses, so in the HelloWorld.sayHelloAll() will result in an error.
