### PR TITLE
Correct constructor reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ function HelloWorld() {
 }
 
 HelloWorld.prototype = Object.create(Hello.prototype);
+HelloWorld.prototype.constructor = HelloWorld;
 HelloWorld.sayHelloAll = Hello.sayHelloAll;
 
 HelloWorld.prototype.echo = function echo() {


### PR DESCRIPTION
Problem:

``` js
var hw = new HelloWorld();
hw.constructor //=> Hello
```

Solution: assign constructor reference

``` js
HelloWorld.prototype = Object.create(Hello.prototype);
HelloWorld.prototype.constructor = HelloWorld;

var hw = new HelloWorld();
hw.constructor //=> HelloWorld
```
