### PR TITLE
Change typo in example filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ export function sum(x, y) {
 export var pi = 3.141593;
 ```
 
-lib/math/js - ES5
+lib/math.js - ES5
 
 ```js
 exports.sum = sum;


### PR DESCRIPTION
Found that the ES5 example uses the `js` directory to import rather than the `math.js` file.
